### PR TITLE
Fix Flask init and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Business Productivity Optimization (BPO)
 
-This repository contains a Flask based time sheet and job card tracking system.
-The application originally lived in `BPO Main/AutoTimeSheet-main` and the root
-of the repository contained a small HTML prototype.  The project has been
-restructured so that the production code resides in `app/` and the prototype
-files are stored in `prototype/`.
+This project implements a small productivity platform.  A Flask API manages
+users, organisations, tasks, job cards and timesheets.  A lightweight React
+front‑end (under `frontend/`) consumes this API.  Older HTML templates are kept
+under `prototype/` for reference.
 
 ## Project Structure
 
@@ -15,21 +14,36 @@ prototype/           # Static prototype for future redesigns
 .gitignore           # Repository ignore rules
 ```
 
+## Features
+
+- User and organisation management
+- Create and update tasks
+- Upload timesheets and job cards
+- React dashboard served separately from the API
+
 See `app/readme.md` for detailed information about the application itself.
 
 ## Running the Application
 
-1. Create a virtual environment and install the requirements:
+1. Create a virtual environment and install the requirements for the Flask
+   server:
    ```bash
    python3 -m venv venv
    source venv/bin/activate
    pip install -r app/requirements.txt
    ```
 2. Copy `.env.example` to `.env` and update the values for your environment.
-3. Run the application:
+3. Start the Flask API:
    ```bash
    export FLASK_APP=app/app.py
    flask run
+   ```
+
+4. In a separate terminal start the React front‑end:
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
    ```
 
 ## Tests

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,13 @@
-#root init
-from .Server_Side_Processing import timesheet2json, totalHourDict, util
-#from inits_for_app import init_extensions, app_extensions
-#from .Server_Side_Processing import updateExcel
-from . import models
-#import models
-from . import init_extensions
-#from . import wsgi
-from . import app
+# Application package initialisation
+"""Expose the :func:`create_app` factory for external imports."""
+
+# These modules are imported so that other parts of the application can use them
+# when ``create_app`` is invoked.  They aren't executed on import which keeps the
+# package lightweight.
+from . import models  # noqa: F401  (re-exported for convenience)
+from . import init_extensions  # noqa: F401
+
+# Re-export the application factory used by ``flask run`` and tests
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,6 @@
 # app.py
 from flask import Flask
+from flask_cors import CORS
 from .init_extensions import setup, login_manager, db
 #import init_extensions
 from .models import User
@@ -10,6 +11,7 @@ from dotenv import load_dotenv
 def create_app(config_class=Config):
     print("setting app environment var")
     app = Flask(__name__)
+    CORS(app)
     print("App environment var set")
     app.config.from_object(Config)
     print("App configured")

--- a/app/init_extensions.py
+++ b/app/init_extensions.py
@@ -11,14 +11,12 @@ mail = Mail()
 bcrypt = Bcrypt()
 
 def setup(app):
-	print("Setting up extensions")
-	bcrypt.init_app(app)
-	print("bcrypt initialized")
-	db.init_app(app)
-	print("db initialized")
-	migrate.init_app(app, db)
-	print("migrate initialized")
-	login_manager.init_app(app)
-	print("login_manager initialized")
-	mail.init_app(app)
-	print("mail initialized")
+    """Initialise extensions for the given Flask application."""
+
+    print("Setting up extensions")
+    bcrypt.init_app(app)
+    db.init_app(app)
+    migrate.init_app(app, db)
+    login_manager.init_app(app)
+    mail.init_app(app)
+    print("Extensions ready")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,6 +4,7 @@ flask_migrate
 flask_login
 flask_mail
 flask_bcrypt
+flask_cors
 flask_wtf
 wtforms
 wtforms[email]


### PR DESCRIPTION
## Summary
- expose `create_app` from package init
- tidy extension setup and enable CORS
- add missing Flask-CORS dependency
- document running the API and React frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486d44d19c83289ad59dc8910ade57