### PR TITLE
Improve login flow and combined server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,15 @@ See `app/readme.md` for detailed information about the application itself.
    pip install -r app/requirements.txt
    ```
 2. Copy `.env.example` to `.env` and update the values for your environment.
-3. Start the Flask API:
-   ```bash
-   export FLASK_APP=app/app.py
-   flask run
-   ```
-
-4. In a separate terminal start the React front‑end:
+3. Install Node dependencies for the front‑end:
    ```bash
    cd frontend
    npm install
-   npm run dev
+   cd ..
+   ```
+4. Start both servers together using the provided helper script:
+   ```bash
+   ./start.sh
    ```
 
 ## Tests

--- a/frontend/src/components/LoginTabs.tsx
+++ b/frontend/src/components/LoginTabs.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Input from './ui/Input';
 import Button from './ui/Button';
 import { Listbox } from '@headlessui/react';
@@ -8,6 +9,12 @@ const orgs = ['Acme Corp', 'Globex', 'Soylent'];
 export default function LoginTabs() {
   const [tab, setTab] = useState<'org' | 'emp' | 'guest'>('org');
   const [selectedOrg, setSelectedOrg] = useState(orgs[0]);
+  const navigate = useNavigate();
+
+  const handleLogin = (e: React.FormEvent) => {
+    e.preventDefault();
+    navigate('/dashboard');
+  };
 
   return (
     <div className="w-full max-w-md mx-auto">\
@@ -17,7 +24,7 @@ export default function LoginTabs() {
         <button className={`flex-1 p-2 ${tab==='guest'?'border-b-2 border-primary':''}`} onClick={()=>setTab('guest')}>Guest</button>
       </div>
       {tab==='org' && (
-        <form className="space-y-4" aria-label="Organisation login form">
+        <form className="space-y-4" aria-label="Organisation login form" onSubmit={handleLogin}>
           <Listbox value={selectedOrg} onChange={setSelectedOrg}>
             <div className="relative">
               <Listbox.Button className="w-full rounded-md border-gray-300 shadow-sm py-2 pl-3 pr-10 text-left focus:border-primary focus:ring-primary">
@@ -35,14 +42,14 @@ export default function LoginTabs() {
         </form>
       )}
       {tab==='emp' && (
-        <form className="space-y-4" aria-label="Employee login form">
+        <form className="space-y-4" aria-label="Employee login form" onSubmit={handleLogin}>
           <Input placeholder="Email" type="email" aria-label="Email" />
           <Input type="password" placeholder="Password" aria-label="Password" />
           <Button type="submit" className="w-full">Login</Button>
         </form>
       )}
       {tab==='guest' && (
-        <form className="space-y-4" aria-label="Guest login form">
+        <form className="space-y-4" aria-label="Guest login form" onSubmit={handleLogin}>
           <Input placeholder="Name" aria-label="Name" />
           <Button type="submit" className="w-full">Enter</Button>
         </form>

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Simple script to run Flask backend and React frontend together
+
+# run flask server
+(
+  cd app
+  export FLASK_APP=app/app.py
+  flask run --port=5000 --host=0.0.0.0 &
+  FLASK_PID=$!
+)
+
+# run React dev server
+(
+  cd frontend
+  npm run dev &
+  NODE_PID=$!
+)
+
+trap "kill $FLASK_PID $NODE_PID" SIGINT
+wait $FLASK_PID $NODE_PID


### PR DESCRIPTION
## Summary
- wire Login page to navigate to the dashboard
- add helper script `start.sh` to run Flask and React together
- update README with unified start instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848716c57ec8328a7b9244f3a095161